### PR TITLE
Fix short address decoding

### DIFF
--- a/contracts/rlp.sol
+++ b/contracts/rlp.sol
@@ -271,11 +271,9 @@ library RLP {
  /// @param self The RLPItem.
  /// @return The decoded string.
  function toAddress(RLPItem memory self) internal pure returns (address data) {
-     (uint rStartPos, uint len) = _decode(self);
-     require(len == 20);
-     assembly {
-         data := div(mload(rStartPos), exp(256, 12))
-     }
+     (, uint len) = _decode(self);
+     require(len <= 20);
+     return address(toUint(self));
  }
 
  // Get the payload offset.


### PR DESCRIPTION
Example addresses:
```
0x0014F55A50b281EFD12294f0Cda821Bd8171e920
0x0000000000000000000000000000000000000000
```